### PR TITLE
Pin third-party actions to currently used SHA

### DIFF
--- a/.github/workflows/coana-guardrail.yml
+++ b/.github/workflows/coana-guardrail.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           separator: ' '
 


### PR DESCRIPTION
In light of the [recent compromise of the tj-actions/changed-files action](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), we’re trying to reduce the risk incurred from our use of third-party actions. 

[GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to a full length commit SHA as a good security practice, and as the only way to use an action as an immutable release.

This PR pins this repository’s third-party actions to their currently used version’s commit SHA, as indicated in the logs for the most recent workflow runs, or from the most recent matching release if logs are not available.

If desired, we can also look into adding a Dependabot configuration to help keep actions updated by automatically creating update PRs when new versions are available.