### PR TITLE
Docs: Fix typo in react router authkit example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 >[!IMPORTANT]
 > This is an early-stage port of [authkit-remix](https://github.com/workos/authkit-remix) to support React Router. The features focus on framework mode (e.g. Remix), with more planned support for library mode and more features.
 
-The AuthKit library for React Router 7+ provides convenient helpers for authentication and session management using WorkOS & AuthKit with React Router. You can find this library in action in the [react-rotuer-authkit-example](https://github.com/workos/react-rotuer-authkit-example) repo.
+The AuthKit library for React Router 7+ provides convenient helpers for authentication and session management using WorkOS & AuthKit with React Router. You can find this library in action in the [react-router-authkit-example](https://github.com/workos/react-router-authkit-example) repo.
 
 ## Installation
 


### PR DESCRIPTION
Fixes typo in the README tag and link to react-router-authkit-example repo.  