### PR TITLE
v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react-router",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with React Router 7+",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { getConfig } from './config.js';
 import { lazy } from './utils.js';
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 
 /**
  * Create a WorkOS instance with the provided API key and optional settings.


### PR DESCRIPTION
This pull request updates the version of the `@workos-inc/authkit-react-router` package and the corresponding `VERSION` constant in the codebase to `0.4.0`, aligning the package metadata and code references.

- Add `withAuth` helper (#16)

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `version` field from `0.3.0` to `0.4.0`.
* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efL5-R5): Updated the `VERSION` constant from `0.3.0` to `0.4.0`.