### PR TITLE
Add Session Refresh Callbacks

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { SessionStorage, SessionIdStorageStrategy, data } from 'react-router';
+import type { SessionStorage, SessionIdStorageStrategy, data, SessionData } from 'react-router';
 import type { OauthTokens, User } from '@workos-inc/node';
 
 export type DataWithResponseInit<T> = ReturnType<typeof data<T>>;
@@ -14,6 +14,19 @@ export interface AuthLoaderSuccessData {
   oauthTokens: OauthTokens | null;
   refreshToken: string;
   user: User;
+}
+
+export interface RefreshErrorOptions {
+  error: unknown;
+  request: Request;
+  sessionData: SessionData;
+}
+
+export interface RefreshSuccessOptions {
+  accessToken: string;
+  user: User;
+  impersonator: Impersonator | null;
+  organizationId: string | null;
 }
 
 export interface Impersonator {
@@ -67,6 +80,8 @@ export interface GetAuthURLOptions {
 export type AuthKitLoaderOptions = {
   ensureSignedIn?: boolean;
   debug?: boolean;
+  onSessionRefreshError?: (options: RefreshErrorOptions) => void | Response | Promise<void | Response>;
+  onSessionRefreshSuccess?: (options: RefreshSuccessOptions) => void | Promise<void>;
 } & (
   | {
       storage?: never;


### PR DESCRIPTION
## Summary

This PR adds callbacks for session refresh success and failure in the AuthKit React Router SDK, providing a more flexible and developer-friendly approach to handling session refreshes.

**Note:** This is a port of [workos/authkit-remix#58](https://github.com/workos/authkit-remix/pull/58) to the React Router library.

## Problem

Previously, when a session refresh failed, the SDK would simply delete the cookie and redirect the user to the root path (/). This hard-coded behavior provided no visibility into why the refresh failed and no way for developers to customize the error handling flow.

## Solution

This PR introduces:

- `onSessionRefreshSuccess` callback - Called when a session is successfully refreshed
- `onSessionRefreshError` callback - Called when a session refresh fails

These callbacks allow developers to implement custom error handling, logging, analytics, and user messaging around session lifecycle events.

## Implementation Details

- Created a `SessionRefreshError` class to properly identify refresh failures
- Modified the session refresh flow to use try/catch pattern

## Example Usage
```typescript
export const loader = async ({ request }) => 
  authkitLoader({ request }, async ({ auth }) => {
    return json({ user: auth.user });
  }, {
    onSessionRefreshError: async ({ error, request, sessionData }) => {
      // Log the error to your monitoring service
      console.error("Session refresh failed:", error);
      
      // You can throw a redirect to a custom error page
      throw redirect("/auth/session-expired");
      
      // Or return a custom response
      // return data({ error: "Your session expired" }, { status: 401 });
    },
    
    onSessionRefreshSuccess: async ({ accessToken, user, organizationId }) => {
      // Track successful refresh
      console.log("Session refreshed for user:", user.id);
    }
  });
```

## Backward Compatibility

To maintain backward compatibility, the default behavior (redirect to `/` and delete cookie) is preserved when no onSessionRefreshError callback is provided.