### PR TITLE
Add support for `feature_flags` claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ export const loader = (args: LoaderFunctionArgs) => authkitLoader(args);
 export function App() {
   // Retrieves the user from the session or returns `null` if no user is signed in
   // Other supported values include `sessionId`, `accessToken`, `organizationId`,
-  // `role`, `permissions`, `entitlements`, and `impersonator`.
+  // `role`, `permissions`, `entitlements`, `featureFlags`, and `impersonator`.
   const { user, signInUrl, signUpUrl } = useLoaderData<typeof loader>();
 
   return (

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -110,6 +110,7 @@ describe('auth', () => {
       role: 'admin' as string | undefined,
       permissions: ['read', 'write'] as string[] | undefined,
       entitlements: ['premium'] as string[] | undefined,
+      featureFlags: ['flag-1', 'flag-2'] as string[] | undefined,
       impersonator: null,
       sealedSession: 'sealed-session-data',
       headers: {
@@ -340,6 +341,7 @@ describe('auth', () => {
         role: 'admin',
         permissions: ['read', 'write'],
         entitlements: ['feature-1', 'feature-2'],
+        featureFlags: ['flag-1', 'flag-2'],
         exp: Date.now() / 1000 + 3600, // 1 hour from now
         iss: 'https://api.workos.com',
       };
@@ -361,6 +363,7 @@ describe('auth', () => {
         role: mockClaims.role,
         permissions: mockClaims.permissions,
         entitlements: mockClaims.entitlements,
+        featureFlags: mockClaims.featureFlags,
         impersonator: mockSession.impersonator,
         accessToken: mockSession.accessToken,
       });
@@ -394,6 +397,7 @@ describe('auth', () => {
         role: 'admin',
         permissions: ['read', 'write'],
         entitlements: ['feature-1', 'feature-2'],
+        featureFlags: ['flag-1', 'flag-2'],
         exp: Date.now() / 1000 - 3600, // 1 hour ago (expired)
         iss: 'https://api.workos.com',
       };
@@ -417,6 +421,7 @@ describe('auth', () => {
         role: mockClaims.role,
         permissions: mockClaims.permissions,
         entitlements: mockClaims.entitlements,
+        featureFlags: mockClaims.featureFlags,
         impersonator: undefined,
         accessToken: mockSession.accessToken,
       });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -49,6 +49,7 @@ export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoU
     organizationId,
     permissions,
     entitlements,
+    featureFlags,
     role,
     exp = 0,
   } = getClaimsFromAccessToken(session.accessToken);
@@ -66,6 +67,7 @@ export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoU
     role,
     permissions,
     entitlements,
+    featureFlags,
     impersonator: session.impersonator,
     accessToken: session.accessToken,
   };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface AccessToken {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  feature_flags?: string[];
 }
 
 export interface UserInfo {
@@ -66,6 +67,7 @@ export interface UserInfo {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  featureFlags?: string[];
   impersonator?: Impersonator;
   accessToken: string;
 }
@@ -77,6 +79,7 @@ export interface NoUserInfo {
   role?: undefined;
   permissions?: undefined;
   entitlements?: undefined;
+  featureFlags?: undefined;
   impersonator?: undefined;
   accessToken?: undefined;
 }
@@ -110,6 +113,7 @@ export interface AuthorizedData {
   role: string | null;
   permissions: string[];
   entitlements: string[];
+  featureFlags: string[];
   impersonator: Impersonator | null;
   sealedSession: string;
 }
@@ -122,6 +126,7 @@ export interface UnauthorizedData {
   role: null;
   permissions: null;
   entitlements: null;
+  featureFlags: null;
   impersonator: null;
   sealedSession: null;
 }

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -282,6 +282,7 @@ describe('session', () => {
           organizationId: null,
           permissions: null,
           entitlements: null,
+          featureFlags: null,
           role: null,
           sessionId: null,
           sealedSession: null,
@@ -352,6 +353,7 @@ describe('session', () => {
           role: 'admin',
           permissions: ['read', 'write'],
           entitlements: ['premium'],
+          feature_flags: ['flag-1', 'flag-2'],
         });
       });
 
@@ -400,6 +402,7 @@ describe('session', () => {
           organizationId: 'org-123',
           permissions: ['read', 'write'],
           entitlements: ['premium'],
+          featureFlags: ['flag-1', 'flag-2'],
           role: 'admin',
           sessionId: 'test-session-id',
           sealedSession: 'encrypted-jwt',
@@ -506,6 +509,7 @@ describe('session', () => {
               role: null,
               permissions: [],
               entitlements: [],
+              feature_flags: [],
             };
           }
           if (token === 'new.valid.token') {
@@ -515,6 +519,7 @@ describe('session', () => {
               role: 'user',
               permissions: ['read'],
               entitlements: ['basic'],
+              feature_flags: ['flag-1'],
             };
           }
           return {}; // fallback
@@ -539,6 +544,7 @@ describe('session', () => {
             role: 'user',
             permissions: ['read'],
             entitlements: ['basic'],
+            featureFlags: ['flag-1'],
           }),
         );
 
@@ -659,6 +665,7 @@ describe('session', () => {
         role: 'user',
         permissions: ['read'],
         entitlements: ['basic'],
+        feature_flags: ['flag-1'],
       });
     });
 
@@ -683,6 +690,7 @@ describe('session', () => {
         role: 'user',
         permissions: ['read'],
         entitlements: ['basic'],
+        featureFlags: ['flag-1'],
         impersonator: null,
         sealedSession: 'encrypted-jwt',
         headers: {

--- a/src/session.ts
+++ b/src/session.ts
@@ -73,6 +73,7 @@ export async function refreshSession(request: Request, { organizationId }: { org
       role,
       permissions,
       entitlements,
+      featureFlags,
     } = getClaimsFromAccessToken(accessToken);
 
     return {
@@ -83,6 +84,7 @@ export async function refreshSession(request: Request, { organizationId }: { org
       role,
       permissions,
       entitlements,
+      featureFlags,
       impersonator: session.impersonator || null,
       sealedSession: cookieSession.get('jwt'),
       headers: newSession.headers,
@@ -323,6 +325,7 @@ export async function authkitLoader<Data = unknown>(
         organizationId: null,
         permissions: null,
         entitlements: null,
+        featureFlags: null,
         role: null,
         sessionId: null,
         sealedSession: null,
@@ -338,6 +341,7 @@ export async function authkitLoader<Data = unknown>(
       role = null,
       permissions = [],
       entitlements = [],
+      featureFlags = [],
     } = getClaimsFromAccessToken(session.accessToken);
 
     const cookieSession = await getSession(request.headers.get('Cookie'));
@@ -361,6 +365,7 @@ export async function authkitLoader<Data = unknown>(
       role,
       permissions,
       entitlements,
+      featureFlags,
       impersonator,
       sealedSession: cookieSession.get('jwt'),
     };
@@ -473,6 +478,7 @@ export function getClaimsFromAccessToken(accessToken: string) {
     role,
     permissions,
     entitlements,
+    feature_flags: featureFlags,
     exp,
     iss,
   } = decodeJwt<AccessToken>(accessToken);
@@ -485,6 +491,7 @@ export function getClaimsFromAccessToken(accessToken: string) {
     role,
     permissions,
     entitlements,
+    featureFlags,
   };
 }
 


### PR DESCRIPTION
Add support for the `feature_flags` claim. This claim will be exposed on the session as `featureFlags` and will contain a list of the string slugs for feature flags that are enabled for the current user session based on organization membership.
```ts
const { featureFlags } = newSession;
if (featureFlags.includes['my_flag']) {
   // ...
}
```