### PR TITLE
v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react-router",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with React Router 7+",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { getConfig } from './config.js';
 import { lazy } from './utils.js';
 
-const VERSION = '0.5.0';
+const VERSION = '0.6.0';
 
 /**
  * Create a WorkOS instance with the provided API key and optional settings.


### PR DESCRIPTION
Bump version of `@workos-inc/authkit-react-router` from `v0.5.0` to `v0.6.0`, which includes:
* #25 