### PR TITLE
Fix organization ID preservation during token refresh

### DIFF
--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -533,6 +533,7 @@ describe('session', () => {
         expect(authenticateWithRefreshToken).toHaveBeenCalledWith({
           clientId: expect.any(String),
           refreshToken: 'refresh.token',
+          organizationId: 'org-123',
         });
 
         // Verify the response contains the new token data

--- a/src/session.ts
+++ b/src/session.ts
@@ -117,10 +117,12 @@ async function updateSession(request: Request, debug: boolean) {
     // istanbul ignore next
     if (debug) console.log(`Session invalid. Refreshing access token that ends in ${session.accessToken.slice(-10)}`);
 
+    const { organizationId } = getClaimsFromAccessToken(session.accessToken);
     // If the session is invalid (i.e. the access token has expired) attempt to re-authenticate with the refresh token
     const { accessToken, refreshToken } = await getWorkOS().userManagement.authenticateWithRefreshToken({
       clientId: getConfig('clientId'),
       refreshToken: session.refreshToken,
+      organizationId,
     });
 
     // istanbul ignore next


### PR DESCRIPTION
## Summary
- Fixes an issue where users were reverting to their default organization after token refresh
- Preserves the current `organizationId` when tokens are automatically refreshed

## Test plan
- [x] Existing tests pass
- [x] Test verifies that `organizationId` is passed during token refresh