### PR TITLE
Fix: Preserve return pathname on session refresh failure

### DIFF
--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -11,10 +11,15 @@ import { authkitLoader, encryptSession, terminateSession, refreshSession } from 
 import { assertIsResponse } from './test-utils/test-helpers.js';
 import { getWorkOS } from './workos.js';
 import { getConfig } from './config.js';
+import { getAuthorizationUrl } from './get-authorization-url.js';
 
 jest.mock('./sessionStorage.js', () => ({
   configureSessionStorage: jest.fn(),
   getSessionStorage: jest.fn(),
+}));
+
+jest.mock('./get-authorization-url.js', () => ({
+  getAuthorizationUrl: jest.fn(),
 }));
 
 // Mock dependencies
@@ -39,6 +44,7 @@ const authenticateWithRefreshToken = jest.mocked(workos.userManagement.authentic
 const getSessionStorage = jest.mocked(getSessionStorageMock);
 const configureSessionStorage = jest.mocked(configureSessionStorageMock);
 const jwtVerify = jest.mocked(jose.jwtVerify);
+const getAuthorizationUrlMock = jest.mocked(getAuthorizationUrl);
 
 function getHeaderValue(headers: HeadersInit | undefined, name: string): string | null {
   if (!headers) {
@@ -113,6 +119,10 @@ describe('session', () => {
       destroySession,
       commitSession,
     });
+
+    // Reset getAuthorizationUrl mock
+    getAuthorizationUrlMock.mockReset();
+    getAuthorizationUrlMock.mockResolvedValue('https://auth.workos.com/oauth/authorize');
   });
 
   describe('encryptSession', () => {
@@ -594,17 +604,26 @@ describe('session', () => {
         expect(getHeaderValue(init?.headers, 'Set-Cookie')).toBe('new-session-cookie');
       });
 
-      it('should redirect to root when refresh fails', async () => {
+      it('should redirect to authorization URL preserving returnPathname when refresh fails', async () => {
         authenticateWithRefreshToken.mockRejectedValue(new Error('Refresh token invalid'));
 
+        // Setup the mock to return a URL with state parameter
+        getAuthorizationUrlMock.mockResolvedValue('https://auth.workos.com/oauth/authorize?state=abc123');
+
         try {
-          await authkitLoader(createLoaderArgs(createMockRequest()));
+          const mockRequest = createMockRequest('test-cookie', 'https://app.example.com/dashboard/settings');
+          await authkitLoader(createLoaderArgs(mockRequest));
           fail('Expected redirect response to be thrown');
         } catch (response: unknown) {
           assertIsResponse(response);
           expect(response.status).toBe(302);
-          expect(response.headers.get('Location')).toBe('/');
+          expect(response.headers.get('Location')).toBe('https://auth.workos.com/oauth/authorize?state=abc123');
           expect(response.headers.get('Set-Cookie')).toBe('destroyed-session-cookie');
+
+          // Verify getAuthorizationUrl was called with the correct returnPathname
+          expect(getAuthorizationUrlMock).toHaveBeenCalledWith({
+            returnPathname: '/dashboard/settings',
+          });
         }
       });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -393,7 +393,8 @@ export async function authkitLoader<Data = unknown>(
         }
       }
 
-      throw redirect('/', {
+      const returnPathname = getReturnPathname(request.url);
+      throw redirect(await getAuthorizationUrl({ returnPathname }), {
         headers: {
           'Set-Cookie': await destroySession(cookieSession),
         },


### PR DESCRIPTION
## Summary
- Fixes redirect behavior when session refresh fails to preserve the user's intended destination
- Aligns behavior with authkit-nextjs implementation
- Improves user experience by maintaining context after re-authentication

## Problem
When a session refresh fails (e.g., due to an expired refresh token), the current implementation redirects users to `/` before sending them to re-authenticate. This causes users to lose their intended destination URL.

For example:
1. User is on `/protected/resource`
2. Session expires and refresh fails with `invalid_grant` error
3. User is redirected to `/` 
4. Then redirected to WorkOS auth
5. After authentication, user returns to `/` instead of `/protected/resource`

## Solution
Changed the redirect behavior to go directly to the authorization URL with the return pathname preserved, matching how authkit-nextjs handles this scenario.

## Test Plan
- [x] Updated existing test to verify return pathname is preserved
- [x] All tests pass
- [x] Manually tested in example app

## Breaking Changes
This changes the default behavior when session refresh fails. Apps that were relying on the redirect to `/` will now see users redirected directly to auth with their return path preserved. This is generally a better UX, but it is a behavior change.

Fixes the issue reported in customer feedback where users lose their place in the app when their session expires.