### PR TITLE
v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react-router",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with React Router 7+",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { getConfig } from './config.js';
 import { lazy } from './utils.js';
 
-const VERSION = '0.8.0';
+const VERSION = '0.8.1';
 
 /**
  * Create a WorkOS instance with the provided API key and optional settings.


### PR DESCRIPTION
This pull request updates the version of the `@workos-inc/authkit-react-router` package from 0.8.0 to 0.8.1. The change ensures consistency in versioning across the package metadata and internal references.

## Updates:

- #36 (fix for #35)

Version bump:

* Updated the `version` field in `package.json` to 0.8.1.
* Changed the internal `VERSION` constant in `src/workos.ts` to 0.8.1.