### PR TITLE
Fix infinite redirects with load balancer TLS termination

### DIFF
--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -249,7 +249,7 @@ describe('authLoader', () => {
       expect(response.status).toBe(302);
 
       // The redirect URL should use HTTPS but preserve the request port (3000)
-      // This documents current behavior - may need adjustment if port should come from config
+      // The redirect URL should use HTTPS and preserve the request port (3000)
       const location = response.headers.get('Location');
       expect(location).toBe('https://example.com:3000/');
       expect(new URL(location!).port).toBe('3000');

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -70,6 +70,14 @@ export function authLoader(options: HandleAuthOptions = {}) {
           });
         }
 
+        // Fix protocol mismatch for load balancer scenarios
+        // If WORKOS_REDIRECT_URI is HTTPS but request is HTTP, use HTTPS for redirect
+        const redirectUri = getConfig('redirectUri');
+        const configUrl = new URL(redirectUri);
+        if (configUrl.protocol === 'https:' && url.protocol === 'http:') {
+          url.protocol = 'https:';
+        }
+
         return redirect(url.toString(), {
           headers: {
             'Set-Cookie': cookie,


### PR DESCRIPTION
## Problem
When running behind a load balancer with TLS termination, users experience infinite redirects because:
- Cookie security is determined by `WORKOS_REDIRECT_URI` protocol (HTTPS = secure cookies)
- Redirect URL is built from `request.url` which is HTTP after load balancer processing
- Browser rejects secure cookie on HTTP redirect → infinite loop

## Solution
Automatically detect protocol mismatch and upgrade redirect URL to HTTPS when `WORKOS_REDIRECT_URI` is HTTPS but request is HTTP.

This ensures the redirect URL protocol matches the cookie security setting, preventing infinite redirects in load balancer scenarios.