### PR TITLE
feat: add authkit action helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,36 @@ export const loader = (args: LoaderFunctionArgs) =>
   });
 ```
 
+### Authenticated actions
+
+AuthKit now provides helpers for React Router **actions** so you can enforce authentication in React Router's actions just as easily as in loaders.
+
+#### `authkitAction`
+
+Use `authkitAction` when you need the full flexibility of optional or required auth, custom storage, or refresh callbacks. Its API mirrors `authkitLoader`, and you receive the same `{ auth, getAccessToken }` arguments inside your action.
+
+```tsx
+import type { ActionFunctionArgs } from 'react-router';
+import { authkitAction } from '@workos-inc/authkit-react-router';
+
+export const action = (args: ActionFunctionArgs) =>
+  authkitAction(args, async ({ auth, getAccessToken }) => {
+    if (!auth.user) {
+      return { status: 'anonymous' };
+    }
+
+    const token = getAccessToken();
+    await fetch('https://api.example.com/secure', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    return { status: 'ok', sessionId: auth.sessionId };
+  });
+```
+
+When the action must always have an authenticated user, pass `{ ensureSignedIn: true }` as the final argument. That guarantees `getAccessToken()` will never return `null` and unauthenticated users will be redirected automatically.
+
 #### Security Considerations
 
 By default, access tokens are not included in the data sent to React components. This helps prevent unintentional token exposure in:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization, withAuth } from './auth.js';
 import { authLoader } from './authkit-callback-route.js';
 import { configure, getConfig } from './config.js';
-import { authkitLoader, refreshSession } from './session.js';
+import { authkitAction, authkitLoader, refreshSession } from './session.js';
 import { getWorkOS } from './workos.js';
 
 export {
   authLoader,
+  authkitAction,
   authkitLoader,
   configure,
   withAuth,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -108,6 +108,8 @@ export type AuthKitLoaderOptions = {
     }
 );
 
+export type AuthKitActionOptions = AuthKitLoaderOptions;
+
 export interface AuthorizedData {
   user: User;
   sessionId: string;


### PR DESCRIPTION
Introduces authkitAction, the action-side equivalent to authkitLoader, so React Router actions get the same session refresh, cookie management, and auth / getAccessToken ergonomics as loaders.