### PR TITLE
v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ used to signal breaking changes.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-27
+
 ### Added
 
 - **PKCE + CSRF protection** on the authorization-code flow. Each sign-in /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react-router",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^8.9.0",
@@ -35,7 +35,7 @@
         "typescript-eslint": "^7.18.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.15.0"
       },
       "peerDependencies": {
         "react": "^18.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react-router",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with React Router 7+",
   "sideEffects": false,
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Cuts a `0.11.0` release for the PKCE / sealed OAuth state work merged in #68.

Per the policy stated in `CHANGELOG.md` — *"While the package is pre-1.0, minor version bumps are used to signal breaking changes"* — this is a **minor** bump despite carrying breaking changes. In strict semver terms it would be major; in this repo's pre-1.0 convention, minor.

### Breaking changes shipping in 0.11.0
- `getSignInUrl` / `getSignUpUrl` / `getAuthorizationUrl` now return `{ url, headers }` instead of a bare URL string. Callers must forward the `Set-Cookie` from `headers` on the redirect that starts the OAuth flow, or the callback will reject the flow as a CSRF failure. See the [migration guide](./README.md#migrating-from-04x).
- Minimum `@workos-inc/node` is `^8.9.0`; `engines.node` is `>=20.15.0` (was `>=20.0.0`) to match `@workos-inc/node@^8.13.x`'s declared engine.

### What this PR contains
- Bumps `package.json` version `0.10.0` → `0.11.0`.
- Cuts `CHANGELOG.md` `[Unreleased]` → `[0.11.0] - 2026-04-27` (entries unchanged from #68).
- Refreshes `package-lock.json` to sync the version bump and the `engines.node` floor that #68 introduced but had been left dirty in the working tree.

No source code changes — all behavioral changes already shipped in #68.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 146 tests passing
- [ ] CI green on this branch
- [ ] After merge: tag `v0.11.0` and publish to npm