### PR TITLE
Add runtime feature flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ used to signal breaking changes.
   client for server-side flag evaluation.
 - `authkitLoader` can now populate `auth.featureFlags` from a Feature Flags
   runtime client via the `featureFlags.runtimeClient` option.
+- `authkitLoader` now supports `onFeatureFlagsError` for reporting runtime
+  feature-flag evaluation failures before falling back to JWT claims.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ used to signal breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- `getFeatureFlagsRuntimeClient` returns a shared WorkOS Feature Flags runtime
+  client for server-side flag evaluation.
+- `authkitLoader` can now populate `auth.featureFlags` from a Feature Flags
+  runtime client via the `featureFlags.runtimeClient` option.
+
+### Changed
+
+- Minimum `@workos-inc/node` is now `^8.13.0` for the Feature Flags runtime
+  client APIs.
+
 ## [0.11.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ export const loader = (args: LoaderFunctionArgs) =>
       runtimeClient: featureFlags,
       waitUntilReady: { timeoutMs: 5000 },
     },
+    onFeatureFlagsError: ({ error }) => {
+      console.error('Feature flags runtime client failed:', error);
+    },
   });
 
 export function Dashboard() {
@@ -204,8 +207,9 @@ the runtime client:
   runtime client using the signed-in user's `userId` and current
   `organizationId`.
 - If runtime evaluation fails, `authkitLoader` falls back to the access token's
-  `feature_flags` claim so authentication can continue. When `debug: true` is
-  enabled, this fallback emits a warning.
+  `feature_flags` claim so authentication can continue. Use
+  `onFeatureFlagsError` to report this fallback to your monitoring system. When
+  `debug: true` is enabled, this fallback also emits a warning.
 
 The `getFeatureFlagsRuntimeClient` helper returns the same runtime client for
 every call in the current server process. Options passed to

--- a/README.md
+++ b/README.md
@@ -188,10 +188,24 @@ export function Dashboard() {
 }
 ```
 
-`authkitLoader` evaluates all known flags for the authenticated user and current
-organization, then returns the enabled flag slugs in `auth.featureFlags`. If
-runtime evaluation fails, it falls back to the access token's `feature_flags`
-claim so authentication can continue.
+After opting in, downstream route code can continue reading
+`auth.featureFlags` as before, but the values normally come from the runtime
+client instead of the JWT. The JWT claim is used only as a fallback if runtime
+evaluation fails.
+
+#### Source of `auth.featureFlags`
+
+`authkitLoader` preserves the existing token-based behavior unless you opt in to
+the runtime client:
+
+- Without `featureFlags.runtimeClient`, `auth.featureFlags` is read from the
+  access token's `feature_flags` claim.
+- With `featureFlags.runtimeClient`, `auth.featureFlags` is evaluated by the
+  runtime client using the signed-in user's `userId` and current
+  `organizationId`.
+- If runtime evaluation fails, `authkitLoader` falls back to the access token's
+  `feature_flags` claim so authentication can continue. When `debug: true` is
+  enabled, this fallback emits a warning.
 
 The `getFeatureFlagsRuntimeClient` helper returns the same runtime client for
 every call in the current server process. Options passed to

--- a/README.md
+++ b/README.md
@@ -155,6 +155,49 @@ export function App() {
 }
 ```
 
+### Evaluate feature flags
+
+By default, `authkitLoader` reads `featureFlags` from the `feature_flags`
+claim in the WorkOS access token. This is convenient for small flag sets, but
+changes are reflected only after the user's access token refreshes.
+
+Use the Feature Flags runtime client when you need server-side flag evaluation
+that stays in sync independently of the user's session. The runtime client keeps
+flag configuration in memory and syncs changes in the background, so create one
+shared instance per server process rather than one client per request.
+
+```tsx
+import { type LoaderFunctionArgs, useLoaderData } from 'react-router';
+import { authkitLoader, getFeatureFlagsRuntimeClient } from '@workos-inc/authkit-react-router';
+
+const featureFlags = getFeatureFlagsRuntimeClient();
+
+export const loader = (args: LoaderFunctionArgs) =>
+  authkitLoader(args, {
+    featureFlags: {
+      runtimeClient: featureFlags,
+      waitUntilReady: { timeoutMs: 5000 },
+    },
+  });
+
+export function Dashboard() {
+  const { featureFlags } = useLoaderData<typeof loader>();
+  const hasAdvancedAnalytics = featureFlags?.includes('advanced-analytics');
+
+  return hasAdvancedAnalytics ? <AdvancedAnalytics /> : <BasicAnalytics />;
+}
+```
+
+`authkitLoader` evaluates all known flags for the authenticated user and current
+organization, then returns the enabled flag slugs in `auth.featureFlags`. If
+runtime evaluation fails, it falls back to the access token's `feature_flags`
+claim so authentication can continue.
+
+The `getFeatureFlagsRuntimeClient` helper returns the same runtime client for
+every call in the current server process. Options passed to
+`getFeatureFlagsRuntimeClient(options)` are only used when the client is created
+for the first time.
+
 ### Sign-in and sign-up routes
 
 `getSignInUrl` and `getSignUpUrl` return a `{ url, headers }` pair. The

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/node": "^8.9.0",
+        "@workos-inc/node": "^8.13.0",
         "iron-session": "^8.0.1",
         "jose": "^5.2.3",
         "tslib": "^2.8.1",
@@ -21,7 +21,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^24.10.3",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "@workos-inc/node": "^8.9.0",
+        "@workos-inc/node": "^8.13.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-require-extensions": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write \"{src,__tests__}/**/*.{js,ts,tsx}\""
   },
   "dependencies": {
-    "@workos-inc/node": "^8.9.0",
+    "@workos-inc/node": "^8.13.0",
     "iron-session": "^8.0.1",
     "jose": "^5.2.3",
     "tslib": "^2.8.1",
@@ -44,7 +44,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^24.10.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@workos-inc/node": "^8.9.0",
+    "@workos-inc/node": "^8.13.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-require-extensions": "^0.1.3",

--- a/src/feature-flags.spec.ts
+++ b/src/feature-flags.spec.ts
@@ -1,0 +1,29 @@
+import type { FeatureFlagsRuntimeClient } from '@workos-inc/node';
+import { getWorkOS } from './workos.js';
+
+describe('feature flags', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('memoizes the feature flags runtime client', async () => {
+    const runtimeClient = {
+      close: jest.fn(),
+      getAllFlags: jest.fn(),
+      getFlag: jest.fn(),
+      getStats: jest.fn(),
+      isEnabled: jest.fn(),
+      waitUntilReady: jest.fn(),
+    } as unknown as FeatureFlagsRuntimeClient;
+    const createRuntimeClient = jest
+      .spyOn(getWorkOS().featureFlags, 'createRuntimeClient')
+      .mockReturnValue(runtimeClient);
+    const { getFeatureFlagsRuntimeClient } = await import('./feature-flags.js');
+
+    expect(getFeatureFlagsRuntimeClient({ pollingIntervalMs: 5000 })).toBe(runtimeClient);
+    expect(getFeatureFlagsRuntimeClient({ pollingIntervalMs: 30000 })).toBe(runtimeClient);
+    expect(createRuntimeClient).toHaveBeenCalledTimes(1);
+    expect(createRuntimeClient).toHaveBeenCalledWith({ pollingIntervalMs: 5000 });
+  });
+});

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,14 @@
+import type { FeatureFlagsRuntimeClient, RuntimeClientOptions } from '@workos-inc/node';
+import { lazy } from './utils.js';
+import { getWorkOS } from './workos.js';
+
+/**
+ * Returns a shared WorkOS Feature Flags runtime client.
+ *
+ * The runtime client keeps feature flag state in sync in the background, so it
+ * should be created once per server process instead of once per request.
+ * Options are only used when the client is created for the first time.
+ */
+export const getFeatureFlagsRuntimeClient = lazy(
+  (options?: RuntimeClientOptions): FeatureFlagsRuntimeClient => getWorkOS().featureFlags.createRuntimeClient(options),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization, withAuth } from './auth.js';
 import { authLoader } from './authkit-callback-route.js';
 import { configure, getConfig } from './config.js';
+import { getFeatureFlagsRuntimeClient } from './feature-flags.js';
 import { authkitLoader, refreshSession, saveSession } from './session.js';
 import { getWorkOS } from './workos.js';
 
@@ -10,6 +11,7 @@ export {
   configure,
   withAuth,
   getConfig,
+  getFeatureFlagsRuntimeClient,
   getSignInUrl,
   getSignUpUrl,
   getWorkOS,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type { SessionStorage, SessionIdStorageStrategy, data, SessionData } from 'react-router';
-import type { AuthenticationResponse, OauthTokens, User } from '@workos-inc/node';
+import type { AuthenticationResponse, FeatureFlagsRuntimeClient, OauthTokens, User } from '@workos-inc/node';
 import * as v from 'valibot';
 
 export type DataWithResponseInit<T> = ReturnType<typeof data<T>>;
@@ -42,6 +42,11 @@ export interface RefreshSuccessOptions {
   user: User;
   impersonator: Impersonator | null;
   organizationId: string | null;
+}
+
+export interface AuthKitFeatureFlagsOptions {
+  runtimeClient: FeatureFlagsRuntimeClient;
+  waitUntilReady?: boolean | { timeoutMs?: number };
 }
 
 export interface Impersonator {
@@ -152,6 +157,7 @@ export type State = v.InferOutput<typeof StateSchema>;
 export type AuthKitLoaderOptions = {
   ensureSignedIn?: boolean;
   debug?: boolean;
+  featureFlags?: AuthKitFeatureFlagsOptions;
   onSessionRefreshError?: (options: RefreshErrorOptions) => void | Response | Promise<void | Response>;
   onSessionRefreshSuccess?: (options: RefreshSuccessOptions) => void | Promise<void>;
 } & (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,6 +44,14 @@ export interface RefreshSuccessOptions {
   organizationId: string | null;
 }
 
+export interface FeatureFlagsErrorOptions {
+  error: unknown;
+  request: Request;
+  user: User;
+  organizationId: string | null;
+  tokenFeatureFlags: string[];
+}
+
 export interface AuthKitFeatureFlagsOptions {
   runtimeClient: FeatureFlagsRuntimeClient;
   waitUntilReady?: boolean | { timeoutMs?: number };
@@ -158,6 +166,7 @@ export type AuthKitLoaderOptions = {
   ensureSignedIn?: boolean;
   debug?: boolean;
   featureFlags?: AuthKitFeatureFlagsOptions;
+  onFeatureFlagsError?: (options: FeatureFlagsErrorOptions) => void | Promise<void>;
   onSessionRefreshError?: (options: RefreshErrorOptions) => void | Response | Promise<void | Response>;
   onSessionRefreshSuccess?: (options: RefreshSuccessOptions) => void | Promise<void>;
 } & (

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, Session as ReactRouterSession, redirect } from 'react-router';
-import { AuthenticationResponse, type User } from '@workos-inc/node';
+import { AuthenticationResponse, type FeatureFlagsRuntimeClient, type User } from '@workos-inc/node';
 import * as ironSession from 'iron-session';
 import * as jose from 'jose';
 import {
@@ -29,6 +29,9 @@ const fakeWorkosInstance = {
     getLogoutUrl: jest.fn(({ sessionId }) => `https://auth.workos.com/logout/${sessionId}`),
     getJwksUrl: jest.fn((clientId: string) => `https://auth.workos.com/oauth/jwks/${clientId}`),
     authenticateWithRefreshToken: jest.fn(),
+  },
+  featureFlags: {
+    createRuntimeClient: jest.fn(),
   },
 };
 
@@ -480,6 +483,66 @@ describe('session', () => {
           roles: ['admin'],
           sessionId: 'test-session-id',
         });
+      });
+
+      it('should populate featureFlags from the runtime client when configured', async () => {
+        const runtimeClient = {
+          waitUntilReady: jest.fn().mockResolvedValue(undefined),
+          getAllFlags: jest.fn().mockReturnValue({
+            'runtime-flag': true,
+            'disabled-runtime-flag': false,
+          }),
+        } as unknown as FeatureFlagsRuntimeClient;
+
+        const { data } = await authkitLoader(createLoaderArgs(createMockRequest()), {
+          featureFlags: {
+            runtimeClient,
+            waitUntilReady: { timeoutMs: 100 },
+          },
+        });
+
+        expect(runtimeClient.waitUntilReady).toHaveBeenCalledWith({ timeoutMs: 100 });
+        expect(runtimeClient.getAllFlags).toHaveBeenCalledWith({
+          userId: mockSessionData.user.id,
+          organizationId: 'org-123',
+        });
+        expect(data).toEqual(
+          expect.objectContaining({
+            featureFlags: ['runtime-flag'],
+          }),
+        );
+      });
+
+      it('should fall back to token feature flags when runtime evaluation fails', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const runtimeClient = {
+          waitUntilReady: jest.fn().mockRejectedValue(new Error('runtime not ready')),
+          getAllFlags: jest.fn(),
+        } as unknown as FeatureFlagsRuntimeClient;
+
+        const { data } = await authkitLoader(createLoaderArgs(createMockRequest()), {
+          debug: true,
+          featureFlags: {
+            runtimeClient,
+            waitUntilReady: true,
+          },
+        });
+
+        expect(runtimeClient.waitUntilReady).toHaveBeenCalledWith(undefined);
+        expect(runtimeClient.getAllFlags).not.toHaveBeenCalled();
+        expect(data).toEqual(
+          expect.objectContaining({
+            featureFlags: ['flag-1', 'flag-2'],
+          }),
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[AuthKit] Failed to evaluate feature flags with the WorkOS runtime client. Falling back to access token feature flags.',
+          expect.any(Error),
+        );
+
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
       });
 
       it('should handle custom loader data', async () => {

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -513,16 +513,17 @@ describe('session', () => {
         );
       });
 
-      it('should fall back to token feature flags when runtime evaluation fails', async () => {
-        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      it('should call onFeatureFlagsError and fall back when waitUntilReady fails', async () => {
+        const error = new Error('runtime not ready');
+        const onFeatureFlagsError = jest.fn();
+        const request = createMockRequest();
         const runtimeClient = {
-          waitUntilReady: jest.fn().mockRejectedValue(new Error('runtime not ready')),
+          waitUntilReady: jest.fn().mockRejectedValue(error),
           getAllFlags: jest.fn(),
         } as unknown as FeatureFlagsRuntimeClient;
 
-        const { data } = await authkitLoader(createLoaderArgs(createMockRequest()), {
-          debug: true,
+        const { data } = await authkitLoader(createLoaderArgs(request), {
+          onFeatureFlagsError,
           featureFlags: {
             runtimeClient,
             waitUntilReady: true,
@@ -536,6 +537,69 @@ describe('session', () => {
             featureFlags: ['flag-1', 'flag-2'],
           }),
         );
+        expect(onFeatureFlagsError).toHaveBeenCalledWith({
+          error,
+          request,
+          user: mockSessionData.user,
+          organizationId: 'org-123',
+          tokenFeatureFlags: ['flag-1', 'flag-2'],
+        });
+      });
+
+      it('should call onFeatureFlagsError and fall back when getAllFlags fails', async () => {
+        const error = new Error('runtime client closed');
+        const onFeatureFlagsError = jest.fn();
+        const request = createMockRequest();
+        const runtimeClient = {
+          waitUntilReady: jest.fn().mockResolvedValue(undefined),
+          getAllFlags: jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        } as unknown as FeatureFlagsRuntimeClient;
+
+        const { data } = await authkitLoader(createLoaderArgs(request), {
+          onFeatureFlagsError,
+          featureFlags: {
+            runtimeClient,
+            waitUntilReady: true,
+          },
+        });
+
+        expect(runtimeClient.waitUntilReady).toHaveBeenCalledWith(undefined);
+        expect(runtimeClient.getAllFlags).toHaveBeenCalledWith({
+          userId: mockSessionData.user.id,
+          organizationId: 'org-123',
+        });
+        expect(data).toEqual(
+          expect.objectContaining({
+            featureFlags: ['flag-1', 'flag-2'],
+          }),
+        );
+        expect(onFeatureFlagsError).toHaveBeenCalledWith({
+          error,
+          request,
+          user: mockSessionData.user,
+          organizationId: 'org-123',
+          tokenFeatureFlags: ['flag-1', 'flag-2'],
+        });
+      });
+
+      it('should log runtime evaluation failures when debug is enabled', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const runtimeClient = {
+          waitUntilReady: jest.fn().mockRejectedValue(new Error('runtime not ready')),
+          getAllFlags: jest.fn(),
+        } as unknown as FeatureFlagsRuntimeClient;
+
+        await authkitLoader(createLoaderArgs(createMockRequest()), {
+          debug: true,
+          featureFlags: {
+            runtimeClient,
+            waitUntilReady: true,
+          },
+        });
+
         expect(warnSpy).toHaveBeenCalledWith(
           '[AuthKit] Failed to evaluate feature flags with the WorkOS runtime client. Falling back to access token feature flags.',
           expect.any(Error),

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,6 +2,7 @@ import { data, redirect, type LoaderFunctionArgs, type SessionData } from 'react
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import type {
   AccessToken,
+  AuthKitFeatureFlagsOptions,
   AuthKitLoaderOptions,
   AuthorizedData,
   DataWithResponseInit,
@@ -17,7 +18,7 @@ import { getConfig } from './config.js';
 import { getPKCECleanupCookieStrings } from './pkce.js';
 import { configureSessionStorage, getSessionStorage } from './sessionStorage.js';
 import { isDataWithResponseInit, isJsonResponse, isRedirect, isResponse } from './utils.js';
-import type { AuthenticationResponse } from '@workos-inc/node';
+import type { AuthenticationResponse, EvaluationContext } from '@workos-inc/node';
 
 // must be a type since this is a subtype of response
 // interfaces must conform to the types they extend
@@ -343,6 +344,7 @@ export async function authkitLoader<Data = unknown>(
     onSessionRefreshError,
     storage,
     cookie,
+    featureFlags: featureFlagsOptions,
   } = typeof loaderOrOptions === 'object' ? loaderOrOptions : options;
 
   const cookieName = cookie?.name ?? getConfig('cookieName');
@@ -395,7 +397,7 @@ export async function authkitLoader<Data = unknown>(
       roles = null,
       permissions = [],
       entitlements = [],
-      featureFlags = [],
+      featureFlags: tokenFeatureFlags = [],
     } = getClaimsFromAccessToken(session.accessToken);
 
     const { impersonator = null } = session;
@@ -409,6 +411,14 @@ export async function authkitLoader<Data = unknown>(
         organizationId,
       });
     }
+
+    const featureFlags = await getFeatureFlags({
+      options: featureFlagsOptions,
+      tokenFeatureFlags,
+      userId: session.user?.id,
+      organizationId,
+      debug,
+    });
 
     const auth: AuthorizedData = {
       user: session.user,
@@ -458,6 +468,52 @@ export async function authkitLoader<Data = unknown>(
 
     // Propagate other errors
     throw error;
+  }
+}
+
+async function getFeatureFlags({
+  options,
+  tokenFeatureFlags,
+  userId,
+  organizationId,
+  debug,
+}: {
+  options?: AuthKitFeatureFlagsOptions;
+  tokenFeatureFlags: string[];
+  userId?: string;
+  organizationId: string | null;
+  debug: boolean;
+}) {
+  if (!options) {
+    return tokenFeatureFlags;
+  }
+
+  try {
+    if (options.waitUntilReady) {
+      await options.runtimeClient.waitUntilReady(options.waitUntilReady === true ? undefined : options.waitUntilReady);
+    }
+
+    const context: EvaluationContext = {};
+    if (userId) {
+      context.userId = userId;
+    }
+    if (organizationId) {
+      context.organizationId = organizationId;
+    }
+
+    return Object.entries(options.runtimeClient.getAllFlags(context))
+      .filter(([, enabled]) => enabled)
+      .map(([flag]) => flag);
+  } catch (error) {
+    // istanbul ignore next
+    if (debug) {
+      console.warn(
+        '[AuthKit] Failed to evaluate feature flags with the WorkOS runtime client. Falling back to access token feature flags.',
+        error,
+      );
+    }
+
+    return tokenFeatureFlags;
   }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,7 @@ import type {
   AuthKitLoaderOptions,
   AuthorizedData,
   DataWithResponseInit,
+  FeatureFlagsErrorOptions,
   Session,
   UnauthorizedData,
   UnwrapData,
@@ -342,6 +343,7 @@ export async function authkitLoader<Data = unknown>(
     debug = false,
     onSessionRefreshSuccess,
     onSessionRefreshError,
+    onFeatureFlagsError,
     storage,
     cookie,
     featureFlags: featureFlagsOptions,
@@ -415,9 +417,12 @@ export async function authkitLoader<Data = unknown>(
     const featureFlags = await getFeatureFlags({
       options: featureFlagsOptions,
       tokenFeatureFlags,
+      request,
+      user: session.user,
       userId: session.user?.id,
       organizationId,
       debug,
+      onFeatureFlagsError,
     });
 
     const auth: AuthorizedData = {
@@ -474,15 +479,21 @@ export async function authkitLoader<Data = unknown>(
 async function getFeatureFlags({
   options,
   tokenFeatureFlags,
+  request,
+  user,
   userId,
   organizationId,
   debug,
+  onFeatureFlagsError,
 }: {
   options?: AuthKitFeatureFlagsOptions;
   tokenFeatureFlags: string[];
+  request: Request;
+  user: FeatureFlagsErrorOptions['user'];
   userId?: string;
   organizationId: string | null;
   debug: boolean;
+  onFeatureFlagsError?: (options: FeatureFlagsErrorOptions) => void | Promise<void>;
 }) {
   if (!options) {
     return tokenFeatureFlags;
@@ -505,6 +516,23 @@ async function getFeatureFlags({
       .filter(([, enabled]) => enabled)
       .map(([flag]) => flag);
   } catch (error) {
+    if (onFeatureFlagsError) {
+      try {
+        await onFeatureFlagsError({
+          error,
+          request,
+          user,
+          organizationId,
+          tokenFeatureFlags,
+        });
+      } catch (callbackError) {
+        // istanbul ignore next
+        if (debug) {
+          console.warn('[AuthKit] Feature flags error callback failed.', callbackError);
+        }
+      }
+    }
+
     // istanbul ignore next
     if (debug) {
       console.warn(

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -14,6 +14,16 @@ describe('utils', () => {
       expect(lazyFn()).toBe('test');
       expect(fn).toHaveBeenCalledTimes(1);
     });
+
+    it('should pass arguments only to the first call', () => {
+      const fn = jest.fn((value: string) => value.toUpperCase());
+      const lazyFn = lazy(fn);
+
+      expect(lazyFn('first')).toBe('FIRST');
+      expect(lazyFn('second')).toBe('FIRST');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledWith('first');
+    });
   });
 
   describe('isRedirect', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,12 +7,12 @@ import { DataWithResponseInit } from './interfaces.js';
  * @param fn - The function to be called once.
  * @returns A function that can only be called once.
  */
-export function lazy<T>(fn: () => T): () => T {
+export function lazy<Args extends unknown[], T>(fn: (...args: Args) => T): (...args: Args) => T {
   let called = false;
   let result: T;
-  return () => {
+  return (...args: Args) => {
     if (!called) {
-      result = fn();
+      result = fn(...args);
       called = true;
     }
     return result;


### PR DESCRIPTION
## Summary
- add a shared `getFeatureFlagsRuntimeClient` helper for the WorkOS Feature Flags runtime client
- allow `authkitLoader` to populate `auth.featureFlags` from a configured runtime client
- add `onFeatureFlagsError` so applications can report runtime evaluation failures before falling back to JWT `feature_flags`
- document token vs runtime-client feature flag source behavior
- bump `@workos-inc/node` minimum to `^8.13.0` for runtime-client APIs

## Test plan
- [x] `npm run prettier`
- [x] `./node_modules/.bin/prettier README.md --check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`