### PR TITLE
fix: Derive expected access token issuer from API origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When retrieving configuration values, AuthKit follows this priority order:
 | `cookieMaxAge`   | `WORKOS_COOKIE_MAX_AGE`  | `34560000` (400 days) | No       | Maximum age of cookie in seconds              |
 | `apiHostname`    | `WORKOS_API_HOSTNAME`    | `api.workos.com`      | No       | WorkOS API hostname                           |
 | `apiPort`        | `WORKOS_API_PORT`        | -                     | No       | Port to use for API calls                     |
-| `issuer`         | `WORKOS_ISSUER`          | API origin            | No       | Expected `iss` claim of access tokens         |
+| `issuer`         | `WORKOS_ISSUER`          | API origin            | No       | Expected `iss` claim of access tokens (comma-separated for multiple) |
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -83,18 +83,18 @@ When retrieving configuration values, AuthKit follows this priority order:
 >
 > To print out the entire config, a `getFullConfig` function is provided for debugging purposes.
 
-| Option           | Environment Variable     | Default                 | Required | Description                                   |
-| ---------------- | ------------------------ | ----------------------- | -------- | --------------------------------------------- |
-| `clientId`       | `WORKOS_CLIENT_ID`       | -                       | Yes      | Your WorkOS Client ID                         |
-| `apiKey`         | `WORKOS_API_KEY`         | -                       | Yes      | Your WorkOS API Key                           |
-| `redirectUri`    | `WORKOS_REDIRECT_URI`    | -                       | Yes      | The callback URL configured in WorkOS         |
-| `cookiePassword` | `WORKOS_COOKIE_PASSWORD` | -                       | Yes      | Password for cookie encryption (min 32 chars) |
-| `cookieName`     | `WORKOS_COOKIE_NAME`     | `wos-session`           | No       | Name of the session cookie                    |
-| `apiHttps`       | `WORKOS_API_HTTPS`       | `true`                  | No       | Whether to use HTTPS for API calls            |
-| `cookieMaxAge`   | `WORKOS_COOKIE_MAX_AGE`  | `34560000` (400 days)   | No       | Maximum age of cookie in seconds              |
-| `apiHostname`    | `WORKOS_API_HOSTNAME`    | `api.workos.com`        | No       | WorkOS API hostname                           |
-| `apiPort`        | `WORKOS_API_PORT`        | -                       | No       | Port to use for API calls                     |
-| `issuer`         | `WORKOS_ISSUER`          | `https://{apiHostname}` | No       | Expected `iss` claim of access tokens         |
+| Option           | Environment Variable     | Default               | Required | Description                                   |
+| ---------------- | ------------------------ | --------------------- | -------- | --------------------------------------------- |
+| `clientId`       | `WORKOS_CLIENT_ID`       | -                     | Yes      | Your WorkOS Client ID                         |
+| `apiKey`         | `WORKOS_API_KEY`         | -                     | Yes      | Your WorkOS API Key                           |
+| `redirectUri`    | `WORKOS_REDIRECT_URI`    | -                     | Yes      | The callback URL configured in WorkOS         |
+| `cookiePassword` | `WORKOS_COOKIE_PASSWORD` | -                     | Yes      | Password for cookie encryption (min 32 chars) |
+| `cookieName`     | `WORKOS_COOKIE_NAME`     | `wos-session`         | No       | Name of the session cookie                    |
+| `apiHttps`       | `WORKOS_API_HTTPS`       | `true`                | No       | Whether to use HTTPS for API calls            |
+| `cookieMaxAge`   | `WORKOS_COOKIE_MAX_AGE`  | `34560000` (400 days) | No       | Maximum age of cookie in seconds              |
+| `apiHostname`    | `WORKOS_API_HOSTNAME`    | `api.workos.com`      | No       | WorkOS API hostname                           |
+| `apiPort`        | `WORKOS_API_PORT`        | -                     | No       | Port to use for API calls                     |
+| `issuer`         | `WORKOS_ISSUER`          | API origin            | No       | Expected `iss` claim of access tokens         |
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -83,17 +83,18 @@ When retrieving configuration values, AuthKit follows this priority order:
 >
 > To print out the entire config, a `getFullConfig` function is provided for debugging purposes.
 
-| Option           | Environment Variable     | Default               | Required | Description                                   |
-| ---------------- | ------------------------ | --------------------- | -------- | --------------------------------------------- |
-| `clientId`       | `WORKOS_CLIENT_ID`       | -                     | Yes      | Your WorkOS Client ID                         |
-| `apiKey`         | `WORKOS_API_KEY`         | -                     | Yes      | Your WorkOS API Key                           |
-| `redirectUri`    | `WORKOS_REDIRECT_URI`    | -                     | Yes      | The callback URL configured in WorkOS         |
-| `cookiePassword` | `WORKOS_COOKIE_PASSWORD` | -                     | Yes      | Password for cookie encryption (min 32 chars) |
-| `cookieName`     | `WORKOS_COOKIE_NAME`     | `wos-session`         | No       | Name of the session cookie                    |
-| `apiHttps`       | `WORKOS_API_HTTPS`       | `true`                | No       | Whether to use HTTPS for API calls            |
-| `cookieMaxAge`   | `WORKOS_COOKIE_MAX_AGE`  | `34560000` (400 days) | No       | Maximum age of cookie in seconds              |
-| `apiHostname`    | `WORKOS_API_HOSTNAME`    | `api.workos.com`      | No       | WorkOS API hostname                           |
-| `apiPort`        | `WORKOS_API_PORT`        | -                     | No       | Port to use for API calls                     |
+| Option           | Environment Variable     | Default                 | Required | Description                                   |
+| ---------------- | ------------------------ | ----------------------- | -------- | --------------------------------------------- |
+| `clientId`       | `WORKOS_CLIENT_ID`       | -                       | Yes      | Your WorkOS Client ID                         |
+| `apiKey`         | `WORKOS_API_KEY`         | -                       | Yes      | Your WorkOS API Key                           |
+| `redirectUri`    | `WORKOS_REDIRECT_URI`    | -                       | Yes      | The callback URL configured in WorkOS         |
+| `cookiePassword` | `WORKOS_COOKIE_PASSWORD` | -                       | Yes      | Password for cookie encryption (min 32 chars) |
+| `cookieName`     | `WORKOS_COOKIE_NAME`     | `wos-session`           | No       | Name of the session cookie                    |
+| `apiHttps`       | `WORKOS_API_HTTPS`       | `true`                  | No       | Whether to use HTTPS for API calls            |
+| `cookieMaxAge`   | `WORKOS_COOKIE_MAX_AGE`  | `34560000` (400 days)   | No       | Maximum age of cookie in seconds              |
+| `apiHostname`    | `WORKOS_API_HOSTNAME`    | `api.workos.com`        | No       | WorkOS API hostname                           |
+| `apiPort`        | `WORKOS_API_PORT`        | -                       | No       | Port to use for API calls                     |
+| `issuer`         | `WORKOS_ISSUER`          | `https://{apiHostname}` | No       | Expected `iss` claim of access tokens         |
 
 > [!NOTE]
 >

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -109,6 +109,16 @@ describe('config', () => {
     expect(typeof getConfig('apiHttps')).toBe('boolean');
   });
 
+  it('parses a comma-separated WORKOS_ISSUER into a list', () => {
+    configure((key) => (key === 'WORKOS_ISSUER' ? 'https://a.example.com, https://b.example.com,' : undefined));
+    expect(getConfig('issuer')).toEqual(['https://a.example.com', 'https://b.example.com']);
+  });
+
+  it('keeps a single WORKOS_ISSUER as a string', () => {
+    configure((key) => (key === 'WORKOS_ISSUER' ? 'https://a.example.com' : undefined));
+    expect(getConfig('issuer')).toBe('https://a.example.com');
+  });
+
   it('throws an error if cookiePassword is too short', () => {
     expect(() => {
       configure({ cookiePassword: 'short' });

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,14 @@ export class Configuration {
         return (isNaN(num) ? undefined : num) as AuthKitConfig[K];
       }
 
+      if (key === 'issuer' && typeof envValue === 'string') {
+        const issuers = envValue
+          .split(',')
+          .map((issuer) => issuer.trim())
+          .filter(Boolean);
+        return (issuers.length <= 1 ? issuers[0] : issuers) as AuthKitConfig[K];
+      }
+
       return envValue as AuthKitConfig[K];
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -261,7 +261,7 @@ export interface AuthKitConfig {
   /**
    * The expected `iss` claim of WorkOS access tokens
    * Equivalent to the WORKOS_ISSUER environment variable
-   * Defaults to `https://${apiHostname}`
+   * Defaults to the configured API origin, e.g. `https://api.workos.com`
    */
   issuer?: string;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -259,6 +259,13 @@ export interface AuthKitConfig {
   apiPort?: number;
 
   /**
+   * The expected `iss` claim of WorkOS access tokens
+   * Equivalent to the WORKOS_ISSUER environment variable
+   * Defaults to `https://${apiHostname}`
+   */
+  issuer?: string;
+
+  /**
    * The maximum age of the session cookie in seconds
    * Equivalent to the WORKOS_COOKIE_MAX_AGE environment variable
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -259,11 +259,11 @@ export interface AuthKitConfig {
   apiPort?: number;
 
   /**
-   * The expected `iss` claim of WorkOS access tokens
-   * Equivalent to the WORKOS_ISSUER environment variable
+   * The expected `iss` claim of WorkOS access tokens, or a list of accepted issuers
+   * Equivalent to the WORKOS_ISSUER environment variable (comma-separated for a list)
    * Defaults to the configured API origin, e.g. `https://api.workos.com`
    */
-  issuer?: string;
+  issuer?: string | string[];
 
   /**
    * The maximum age of the session cookie in seconds

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -460,13 +460,45 @@ describe('session', () => {
         jsonSpy.mockRestore();
       });
 
-      it('validates the access token issuer claim against https://api.workos.com', async () => {
+      it('validates the access token issuer claim against https://api.workos.com by default', async () => {
         await authkitLoader(createLoaderArgs(createMockRequest()));
 
         expect(jwtVerify).toHaveBeenCalled();
         for (const call of jwtVerify.mock.calls) {
           expect(call[0]).toBe('valid.jwt.token');
           expect(call[2]).toEqual({ issuer: 'https://api.workos.com' });
+        }
+      });
+
+      it('derives the expected issuer from apiHostname', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_API_HOSTNAME = 'api.workos-test.com';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_API_HOSTNAME;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({ issuer: 'https://api.workos-test.com' });
+        }
+      });
+
+      it('prefers an explicitly configured issuer over apiHostname', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_API_HOSTNAME = 'api.workos-test.com';
+        process.env.WORKOS_ISSUER = 'https://auth.example.com';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_API_HOSTNAME;
+          delete process.env.WORKOS_ISSUER;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({ issuer: 'https://auth.example.com' });
         }
       });
 

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -485,6 +485,40 @@ describe('session', () => {
         }
       });
 
+      it('derives an http issuer with a custom port from apiHttps and apiPort', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_API_HOSTNAME = 'localhost';
+        process.env.WORKOS_API_HTTPS = 'false';
+        process.env.WORKOS_API_PORT = '7000';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_API_HOSTNAME;
+          delete process.env.WORKOS_API_HTTPS;
+          delete process.env.WORKOS_API_PORT;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({ issuer: 'http://localhost:7000' });
+        }
+      });
+
+      it('derives an https issuer with a custom port from apiPort', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_API_PORT = '8443';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_API_PORT;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({ issuer: 'https://api.workos.com:8443' });
+        }
+      });
+
       it('prefers an explicitly configured issuer over apiHostname', async () => {
         jwtVerify.mockClear();
         process.env.WORKOS_API_HOSTNAME = 'api.workos-test.com';

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -536,6 +536,23 @@ describe('session', () => {
         }
       });
 
+      it('accepts a comma-separated list of issuers', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_ISSUER = 'https://auth.example.com,https://api.workos.com/user_management/client_123';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_ISSUER;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({
+            issuer: ['https://auth.example.com', 'https://api.workos.com/user_management/client_123'],
+          });
+        }
+      });
+
       it('should return authorized data with session claims', async () => {
         const { data } = await authkitLoader(createLoaderArgs(createMockRequest()));
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -771,22 +771,24 @@ function getJWKS(): ReturnType<typeof createRemoteJWKSet> {
   }
   return cachedJWKS;
 }
-// WorkOS access tokens carry a fixed `iss` claim regardless of environment
-// or client id; see
+// The `iss` claim on WorkOS access tokens is the API host that minted the
+// token (e.g. `https://api.workos.com`), or a custom issuer when the
+// environment has one configured; see
 // https://workos.com/docs/reference/user-management/session-tokens/access-token.
 // Validating it defends against tokens signed by a different WorkOS project
-// whose JWKS happens to resolve to the same keys, and matches the team's
-// "always validate iss" JWT rule.
+// whose JWKS happens to resolve to the same keys.
 //
 // WorkOS access tokens do not carry a standard `aud` claim — the target
 // client is encoded as `client_id` instead — so we do not pass `audience`
 // to jwtVerify here; doing so would reject every token.
-const WORKOS_JWT_ISSUER = 'https://api.workos.com';
+function getExpectedIssuer(): string {
+  return getConfig('issuer') ?? `https://${getConfig('apiHostname')}`;
+}
 
 async function verifyAccessToken(accessToken: string) {
   const JWKS = getJWKS();
   try {
-    await jwtVerify(accessToken, JWKS, { issuer: WORKOS_JWT_ISSUER });
+    await jwtVerify(accessToken, JWKS, { issuer: getExpectedIssuer() });
     return true;
   } catch (e) {
     return false;

--- a/src/session.ts
+++ b/src/session.ts
@@ -781,7 +781,7 @@ function getJWKS(): ReturnType<typeof createRemoteJWKSet> {
 // WorkOS access tokens do not carry a standard `aud` claim — the target
 // client is encoded as `client_id` instead — so we do not pass `audience`
 // to jwtVerify here; doing so would reject every token.
-function getExpectedIssuer(): string {
+function getExpectedIssuer(): string | string[] {
   const issuer = getConfig('issuer');
   if (issuer) {
     return issuer;

--- a/src/session.ts
+++ b/src/session.ts
@@ -782,7 +782,14 @@ function getJWKS(): ReturnType<typeof createRemoteJWKSet> {
 // client is encoded as `client_id` instead — so we do not pass `audience`
 // to jwtVerify here; doing so would reject every token.
 function getExpectedIssuer(): string {
-  return getConfig('issuer') ?? `https://${getConfig('apiHostname')}`;
+  const issuer = getConfig('issuer');
+  if (issuer) {
+    return issuer;
+  }
+
+  const protocol = getConfig('apiHttps') ? 'https' : 'http';
+  const port = getConfig('apiPort');
+  return `${protocol}://${getConfig('apiHostname')}${port ? `:${port}` : ''}`;
 }
 
 async function verifyAccessToken(accessToken: string) {


### PR DESCRIPTION
## Summary

Fixes #83.

`verifyAccessToken` pinned the expected `iss` claim to the literal `https://api.workos.com`, so any deployment with a non-default `apiHostname` (e.g. `api.workos-test.com`) failed verification on every request and silently fell into the refresh path in `updateSession` — rotating the refresh token and emitting a new `Set-Cookie` on each loader run.

The expected issuer is now configurable and defaults to the API origin the WorkOS client is already built from (`apiHttps` + `apiHostname` + `apiPort`):

```ts
// src/session.ts
function getExpectedIssuer(): string | string[] {
  const issuer = getConfig('issuer');
  if (issuer) return issuer;
  const protocol = getConfig('apiHttps') ? 'https' : 'http';
  const port = getConfig('apiPort');
  return `${protocol}://${getConfig('apiHostname')}${port ? `:${port}` : ''}`;
}
await jwtVerify(accessToken, JWKS, { issuer: getExpectedIssuer() });
```

New `AuthKitConfig.issuer?: string | string[]` option (env `WORKOS_ISSUER`) for environments whose tokens carry a different `iss` than the API origin (the API can mint `iss` from a custom auth domain, or with a `/user_management/<clientId>`, `/sso/<clientId>` or `/convex/<clientId>` path suffix). A list is accepted for apps that need to trust more than one issuer (e.g. during an issuer migration); `jose`'s `issuer` option already accepts `string | string[]`, so it is forwarded as-is. `WORKOS_ISSUER` is split on commas in `getValue` (trimmed, empties dropped; a single value stays a string):

```ts
configure({ issuer: 'https://auth.example.com' });
configure({ issuer: ['https://api.workos.com', 'https://api.workos.com/user_management/client_123'] });
// WORKOS_ISSUER=https://api.workos.com,https://api.workos.com/user_management/client_123
```

Behavior with default config is unchanged (`https://api.workos.com`).

## Test plan

- New specs in `session.spec.ts`: default stays `https://api.workos.com`; `WORKOS_API_HOSTNAME=api.workos-test.com` → `https://api.workos-test.com`; `WORKOS_API_HTTPS=false` + `WORKOS_API_PORT=7000` → `http://localhost:7000`; `WORKOS_API_PORT=8443` → `https://api.workos.com:8443`; `WORKOS_ISSUER` wins over the derived origin; comma-separated `WORKOS_ISSUER` is forwarded to `jwtVerify` as an array.
- `config.spec.ts`: comma-separated `WORKOS_ISSUER` parses to a list; a single value stays a string.
- `npm test`, `npm run lint`, `npm run typecheck` pass locally.

Link to Devin session: https://app.devin.ai/sessions/0ee38e859a9849658a7cdb2d215d89a6
Open in Devin Desktop: https://app.devin.ai/desktop/session/0ee38e859a9849658a7cdb2d215d89a6?variant=devin
Requested by: @m0tzy